### PR TITLE
Provide explicit reference to self in default template inputs

### DIFF
--- a/default/flake.nix
+++ b/default/flake.nix
@@ -6,7 +6,7 @@
 
   # Flake outputs
   outputs =
-    inputs:
+    { self, ... }@inputs:
     let
       # The systems supported for this flake's outputs
       supportedSystems = [


### PR DESCRIPTION
We've been encouraging people to do things like pass `self` to `src` instead of `./.` and we generally prefer this pattern internally.
